### PR TITLE
Remove Ownable from Registry.sol

### DIFF
--- a/contracts/v3/core/Registry.sol
+++ b/contracts/v3/core/Registry.sol
@@ -2,11 +2,10 @@ pragma solidity ^0.7.0;
 
 // SPDX-License-Identifier: MIT
 
-import '../utils/Ownable.sol';
 import '../adapters/interfaces/IOnboarding.sol';
 import './Module.sol';
 
-contract Registry is Ownable, Module {
+contract Registry is Module {
     mapping(bytes32 => address) registry;
     mapping(address => bytes32) inverseRegistry;
 


### PR DESCRIPTION
Registry does not need Ownable to track owner of itself as it is being tracked in registry mapping itself as a module. We need to remove it to avoid inconsistent values in two ownership variables `_owner` from Ownable and `registry` mapping